### PR TITLE
Add missing data cleaning for Zenodo

### DIFF
--- a/src/create_dataset.py
+++ b/src/create_dataset.py
@@ -1,4 +1,5 @@
 import argparse
+import numpy as np
 import os
 import pandas as pd
 from pathlib import Path
@@ -130,7 +131,8 @@ def _read_and_format_zenodo_news_as_df(data_dir: str) -> pd.DataFrame:
     path = os.path.join(data_dir, 'zenodo-swahili-news-train.csv')
     df = pd.read_csv(path).rename(columns={"id": "id/path", "content": "document_content", "category": "document_type"})
     df['document_content'] = df['document_content'].apply(clean)
-    return df
+    df.replace('', np.nan, inplace=True)
+    return df.dropna()
 
 
 def _get_document_type(abs_path: str) -> str:


### PR DESCRIPTION
We allowed a PR to be merged that did not do any data cleaning on the Zenodo dataset :cry: . I was looking through the "cleaned" stemming map and realized it wasn't very clean.

 I think we need to re-run `download_stemming` on this new data.